### PR TITLE
Don't fail if ipv6 isn't available

### DIFF
--- a/usr/bin/whonix-gateway-firewall
+++ b/usr/bin/whonix-gateway-firewall
@@ -780,7 +780,9 @@ main() {
    ipv4_forward
    ipv4_reject_invalid_outgoing_packages
    ipv4_output
-   ipv6 || true
+   if [ -d /proc/sys/net/ipv6/ ]; then
+     ipv6
+   fi
    status_files
    end
 }

--- a/usr/bin/whonix-gateway-firewall
+++ b/usr/bin/whonix-gateway-firewall
@@ -780,7 +780,7 @@ main() {
    ipv4_forward
    ipv4_reject_invalid_outgoing_packages
    ipv4_output
-   ipv6
+   ipv6 || true
    status_files
    end
 }

--- a/usr/bin/whonix-workstation-firewall
+++ b/usr/bin/whonix-workstation-firewall
@@ -593,7 +593,9 @@ main() {
    ipv4_forward
    ipv4_reject_invalid_outgoing_packages
    ipv4_output
-   ipv6 || true
+   if [ -d /proc/sys/net/ipv6/ ]; then
+     ipv6
+   fi
    status_files
    end
 }

--- a/usr/bin/whonix-workstation-firewall
+++ b/usr/bin/whonix-workstation-firewall
@@ -593,7 +593,7 @@ main() {
    ipv4_forward
    ipv4_reject_invalid_outgoing_packages
    ipv4_output
-   ipv6
+   ipv6 || true
    status_files
    end
 }


### PR DESCRIPTION
So whonix-firewall doesn't fail when using hardened-vm-kernel.