### PR TITLE
Allow related in addition to established connections

### DIFF
--- a/usr/bin/whonix-gateway-firewall
+++ b/usr/bin/whonix-gateway-firewall
@@ -356,7 +356,7 @@ ipv4_input_rules() {
    $iptables_cmd -A INPUT -i lo -j ACCEPT
 
    ## Established incoming connections are accepted.
-   $iptables_cmd -A INPUT -m state --state ESTABLISHED -j ACCEPT
+   $iptables_cmd -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
 
    ## Drop all incoming ICMP traffic by default.
    ## All incoming connections are dropped by default anyway, but should a user

--- a/usr/bin/whonix-host-firewall
+++ b/usr/bin/whonix-host-firewall
@@ -142,7 +142,7 @@ iptables -A INPUT -p tcp --tcp-flags ALL NONE -j DROP
 iptables -A INPUT -i lo -j ACCEPT
 
 ## Established incoming connections are accepted.
-iptables -A INPUT -m state --state ESTABLISHED -j ACCEPT
+iptables -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
 
 ## Drop all incoming ICMP traffic by default.
 ## All incoming connections are dropped by default anyway, but should a user
@@ -225,7 +225,7 @@ if [ "$VPN_FIREWALL" = "1" ]; then
 fi
 
 ## Existing connections are accepted.
-iptables -A OUTPUT -m state --state ESTABLISHED -j ACCEPT
+iptables -A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
 
 ## Accept outgoing connections to local network, Whonix-Workstation and VirtualBox,
 ## unless VPN_FIREWALL mode is enabled.

--- a/usr/bin/whonix-workstation-firewall
+++ b/usr/bin/whonix-workstation-firewall
@@ -234,7 +234,7 @@ ipv4_input_rules() {
    $iptables_cmd -A INPUT -i lo -j ACCEPT
 
    ## Established incoming connections are accepted.
-   $iptables_cmd -A INPUT -m state --state ESTABLISHED -j ACCEPT
+   $iptables_cmd -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
 
    ## Allow all incoming connections on the virtual VPN network interface,
    ## when TUNNEL_FIREWALL_ENABLE mode is enabled.


### PR DESCRIPTION
We want certain related packages to be accepted. In particular,
I've run into issues using a VPN in front of a Whonix Gateway. This
because the related Fragmentation Needed packages get dropped:

 1780 280.196298  10.137.0.31 → 10.137.0.19  ICMP 590 Destination unreachable (Fragmentation needed)

With those packages not being delivered, a connection can be
established and works fine until a large package is sent. However,
once that happens no more packages can be delivered and the
connection times out after a while.

There is probably also a bunch of other, related packages that
we want to be delivered. ICMP host unreachable comes to mind, for
instance. Without it being delivered, one has to wait for
the connection attempt to timeout.

Note: Related connections appear to have been disabled in
414c2105149e02 but with no clear indication to why.