### PR TITLE
add opt-in configuration for incoming Related connections through 'gateway_allow_incoming_related_state'

### DIFF
--- a/usr/bin/whonix-gateway-firewall
+++ b/usr/bin/whonix-gateway-firewall
@@ -379,8 +379,14 @@ ipv4_input_rules() {
   ## Traffic on the loopback interface is accepted.
   $iptables_cmd -A INPUT -i lo -j ACCEPT
 
-  ## Established incoming connections are accepted.
-  $iptables_cmd -A INPUT -m state --state ESTABLISHED -j ACCEPT
+  ## Established incoming connections are always accepted.
+  ## Optionally, allow Related incoming connections when
+  ## GATEWAY_ALLOW_INCOMING_RELATED_STATE mode is enabled.
+  if [ "$GATEWAY_ALLOW_INCOMING_RELATED_STATE" = "1" ]; then
+    $iptables_cmd -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
+  else
+    $iptables_cmd -A INPUT -m state --state ESTABLISHED -j ACCEPT
+  fi
 
   ## Drop all incoming ICMP traffic by default.
   ## All incoming connections are dropped by default anyway, but should a user


### PR DESCRIPTION
When running a freshly installed Whonix-Gateway (confirmed that at least 16.0.9.8 and 16.0.9.0 are affected) on a KVM host (note: with Kicksecure installed on the host), Tor gets stuck at 30% when attempting to bootstrap.

(Appears to be the same issue as here: https://forums.whonix.org/t/tor-is-not-yet-fully-bootstrapped-30-done/8792/2)

When I enable the new configuration option "GATEWAY_ALLOW_INCOMING_RELATED_STATE" in file "/usr/local/etc/whonix_firewall.d/50_user.conf", this allows the connection to complete successfully every time.

When I disable the "GATEWAY_ALLOW_INCOMING_RELATED_STATE" option I observe that the issue returns.

I saw a suggestion on the Whonix forums (I believe from Patrick Schleizer) that this could be made into a configuration option. Rather than wasting time replying saying: "yes please I would love this", I've gone ahead and made the necessary changes myself.

Tested on my end and confirmed that this is working as expected.