### PR TITLE
Revert commit f604259 and fix the MTU problem by allowing only RELATED fragmentation-needed ICMP packets instead of all RELATED connections

### DIFF
--- a/etc/whonix_firewall.d/30_whonix_gateway_default.conf
+++ b/etc/whonix_firewall.d/30_whonix_gateway_default.conf
@@ -281,11 +281,13 @@ NO_REJECT_INVALID_OUTGOING_PACKAGES=0
 ##         10.0.2.2-10.0.2.24 \
 ##      "
 
-## Drop all incoming ICMP traffic.
+## Allow fragmentation-needed ICMP packets to avoid MTU problems
+## when Whonix Gateway is connected to a link that has smaller
+## MTU than 1500 assumed by Whonix Gateway
 ## Enable: 1
 ## Disable: 0
 ## DISABLED BY DEFAULT
-GATEWAY_ALLOW_INCOMING_ICMP=0
+GATEWAY_ALLOW_INCOMING_ICMP_FRAG_NEEDED=0
 
 ## Setting firewall_mode always to full by default because the following
 ## usability issues are not yet resolved. Help welcome!

--- a/etc/whonix_firewall.d/30_whonix_host_default.conf
+++ b/etc/whonix_firewall.d/30_whonix_host_default.conf
@@ -68,8 +68,10 @@ NO_REJECT_INVALID_OUTGOING_PACKAGES=0
 ## 10.0.2.2/24: VirtualBox DHCP
 #NON_TOR_GATEWAY="192.168.1.0/24 192.168.0.0/24 127.0.0.0/8 10.152.152.0/24 10.0.2.2/24"
 
-## Drop all incoming ICMP traffic.
+## Allow fragmentation-needed ICMP packets to avoid MTU problems
+## when Whonix Gateway is connected to a link that has smaller
+## MTU than 1500 assumed by Whonix Gateway
 ## Enable: 1
 ## Disable: 0
 ## DISABLED BY DEFAULT
-GATEWAY_ALLOW_INCOMING_ICMP=0
+GATEWAY_ALLOW_INCOMING_ICMP_FRAG_NEEDED=0

--- a/usr/bin/whonix-gateway-firewall
+++ b/usr/bin/whonix-gateway-firewall
@@ -379,22 +379,21 @@ ipv4_input_rules() {
   ## Traffic on the loopback interface is accepted.
   $iptables_cmd -A INPUT -i lo -j ACCEPT
 
-  ## Established incoming connections are always accepted.
-  ## Optionally, allow Related incoming connections when
-  ## GATEWAY_ALLOW_INCOMING_RELATED_STATE mode is enabled.
-  if [ "$GATEWAY_ALLOW_INCOMING_RELATED_STATE" = "1" ]; then
-    $iptables_cmd -A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT
-  else
-    $iptables_cmd -A INPUT -m state --state ESTABLISHED -j ACCEPT
+  ## Established incoming connections are accepted.
+  $iptables_cmd -A INPUT -m state --state ESTABLISHED -j ACCEPT
+
+  ## Allow fragmentation-needed ICMP packets to avoid MTU problems
+  ## when Whonix Gateway is connected to a link that has smaller
+  ## MTU than 1500 assumed by Whonix Gateway
+  if [ "$GATEWAY_ALLOW_INCOMING_ICMP_FRAG_NEEDED" = "1" ]; then
+    $iptables_cmd -A INPUT -p icmp --icmp-type fragmentation-needed -m state --state RELATED -j ACCEPT
   fi
 
   ## Drop all incoming ICMP traffic by default.
   ## All incoming connections are dropped by default anyway, but should a user
   ## allow incoming ports (such as for incoming SSH or FlashProxy), ICMP should
   ## still be dropped to filter for example ICMP time stamp requests.
-  if [ ! "$GATEWAY_ALLOW_INCOMING_ICMP" = "1" ]; then
-    $iptables_cmd -A INPUT -p icmp -j DROP
-  fi
+  $iptables_cmd -A INPUT -p icmp -j DROP
 
   ## Allow all incoming connections on the virtual VPN network interface,
   ## when VPN_FIREWALL mode is enabled.

--- a/usr/bin/whonix-gateway-firewall.nftables
+++ b/usr/bin/whonix-gateway-firewall.nftables
@@ -90,7 +90,7 @@ variables_defaults() {
   [ -n "$ALLOW_GATEWAY_ROOT_USER" ] || ALLOW_GATEWAY_ROOT_USER=0
   [ -n "$ALLOW_GATEWAY_USER_USER" ] || ALLOW_GATEWAY_USER_USER=0
   [ -n "$GATEWAY_ALLOW_INCOMING_SSH" ] || GATEWAY_ALLOW_INCOMING_SSH=0
-  [ -n "$GATEWAY_ALLOW_INCOMING_ICMP" ] || GATEWAY_ALLOW_INCOMING_ICMP=0
+  [ -n "$GATEWAY_ALLOW_INCOMING_ICMP_FRAG_NEEDED" ] || GATEWAY_ALLOW_INCOMING_ICMP_FRAG_NEEDED=0
 
   ## Get Tor username, distro specific!
   [ -n "$TOR_USER" ] || TOR_USER="$(id -u debian-tor)"
@@ -439,14 +439,20 @@ nft_input_rules() {
     $nftables_cmd add rule ip filter INPUT ct state established counter accept
   fi
 
+  ## Allow fragmentation-needed ICMP packets to avoid MTU problems
+  ## when Whonix Gateway is connected to a link that has smaller
+  ## MTU than 1500 assumed by Whonix Gateway
+  if [ "$GATEWAY_ALLOW_INCOMING_ICMP_FRAG_NEEDED" = "1" ]; then
+    #$iptables_cmd -A INPUT -p icmp --icmp-type fragmentation-needed -m state --state RELATED -j ACCEPT
+    $nftables_cmd add rule filter INPUT icmp type destination-unreachable icmp code frag-needed ct state related counter accept
+  fi
+
   ## Drop all incoming ICMP traffic by default.
   ## All incoming connections are dropped by default anyway, but should a user
   ## allow incoming ports (such as for incoming SSH or FlashProxy), ICMP should
   ## still be dropped to filter for example ICMP time stamp requests.
-  if [ ! "$GATEWAY_ALLOW_INCOMING_ICMP" = "1" ]; then
-    #$iptables_cmd -A INPUT -p icmp -j DROP
-    $nftables_cmd add rule ip filter INPUT ip protocol icmp counter drop
-  fi
+  #$iptables_cmd -A INPUT -p icmp -j DROP
+  $nftables_cmd add rule ip filter INPUT ip protocol icmp counter drop
 
   ## Allow all incoming connections on the virtual VPN network interface,
   ## when VPN_FIREWALL mode is enabled.

--- a/usr/bin/whonix-host-firewall
+++ b/usr/bin/whonix-host-firewall
@@ -147,13 +147,18 @@ iptables -A INPUT -i lo -j ACCEPT
 ## Established incoming connections are accepted.
 iptables -A INPUT -m state --state ESTABLISHED -j ACCEPT
 
+## Allow fragmentation-needed ICMP packets to avoid MTU problems
+## when Whonix Gateway is connected to a link that has smaller
+## MTU than 1500 assumed by Whonix Gateway
+if [ "$GATEWAY_ALLOW_INCOMING_ICMP_FRAG_NEEDED" = "1" ]; then
+  iptables -A INPUT -p icmp --icmp-type fragmentation-needed -m state --state RELATED -j ACCEPT
+fi
+
 ## Drop all incoming ICMP traffic by default.
 ## All incoming connections are dropped by default anyway, but should a user
 ## allow incoming ports (such as for incoming SSH or FlashProxy), ICMP should
 ## still be dropped to filter for example ICMP time stamp requests.
-if [ ! "$GATEWAY_ALLOW_INCOMING_ICMP" = "1" ]; then
-  iptables -A INPUT -p icmp -j DROP
-fi
+iptables -A INPUT -p icmp -j DROP
 
 ## Allow all incoming connections on the virtual VPN network interface,
 ## when VPN_FIREWALL mode is enabled.


### PR DESCRIPTION
Revert commit f604259dd55e5dde4765ac7e2ad095d95258caa0 and fix the MTU problem by allowing only RELATED fragmentation-needed ICMP packets instead of all RELATED connections.
Removes configuration option `GATEWAY_ALLOW_INCOMING_RELATED_STATE` from reverted commit and changes option `GATEWAY_ALLOW_INCOMING_ICMP` to `GATEWAY_ALLOW_INCOMING_ICMP_FRAG_NEEDED`.

Check the reverted commit and forum for more info:
https://github.com/Whonix/whonix-firewall/pull/3/commits/f604259dd55e5dde4765ac7e2ad095d95258caa0
http://forums.dds6qkxpwdeubwucdiaord2xgbbeyds25rbsgr73tbfpqpt4a6vjwsyd.onion/t/have-firewall-accept-icmp-fragmentation-needed/10233
http://forums.dds6qkxpwdeubwucdiaord2xgbbeyds25rbsgr73tbfpqpt4a6vjwsyd.onion/t/tor-is-not-yet-fully-bootstrapped-30-done/8792