### PR TITLE
Fix MTU problem by allowing RELATED fragmentation-needed ICMP

### DIFF
--- a/etc/whonix_firewall.d/30_whonix_gateway_default.conf
+++ b/etc/whonix_firewall.d/30_whonix_gateway_default.conf
@@ -287,6 +287,14 @@ NO_REJECT_INVALID_OUTGOING_PACKAGES=0
 ## DISABLED BY DEFAULT
 GATEWAY_ALLOW_INCOMING_ICMP=0
 
+## Allow fragmentation-needed ICMP packets to avoid MTU problems
+## when Whonix Gateway is connected to a link that has smaller
+## MTU than 1500 assumed by Whonix Gateway
+## Enable: 1
+## Disable: 0
+## DISABLED BY DEFAULT
+GATEWAY_ALLOW_INCOMING_ICMP_FRAG_NEEDED=0
+
 ## Setting firewall_mode always to full by default because the following
 ## usability issues are not yet resolved. Help welcome!
 ## Non-Qubes-Whonix: enable sdwdate-gui systray by default

--- a/etc/whonix_firewall.d/30_whonix_host_default.conf
+++ b/etc/whonix_firewall.d/30_whonix_host_default.conf
@@ -73,3 +73,11 @@ NO_REJECT_INVALID_OUTGOING_PACKAGES=0
 ## Disable: 0
 ## DISABLED BY DEFAULT
 GATEWAY_ALLOW_INCOMING_ICMP=0
+
+## Allow fragmentation-needed ICMP packets to avoid MTU problems
+## when Whonix Gateway is connected to a link that has smaller
+## MTU than 1500 assumed by Whonix Gateway
+## Enable: 1
+## Disable: 0
+## DISABLED BY DEFAULT
+GATEWAY_ALLOW_INCOMING_ICMP_FRAG_NEEDED=0

--- a/usr/bin/whonix-gateway-firewall
+++ b/usr/bin/whonix-gateway-firewall
@@ -388,6 +388,13 @@ ipv4_input_rules() {
     $iptables_cmd -A INPUT -m state --state ESTABLISHED -j ACCEPT
   fi
 
+  ## Allow fragmentation-needed ICMP packets to avoid MTU problems
+  ## when Whonix Gateway is connected to a link that has smaller
+  ## MTU than 1500 assumed by Whonix Gateway
+  if [ "$GATEWAY_ALLOW_INCOMING_ICMP_FRAG_NEEDED" = "1" ]; then
+    $iptables_cmd -A INPUT -p icmp --icmp-type fragmentation-needed -m state --state RELATED -j ACCEPT
+  fi
+  
   ## Drop all incoming ICMP traffic by default.
   ## All incoming connections are dropped by default anyway, but should a user
   ## allow incoming ports (such as for incoming SSH or FlashProxy), ICMP should

--- a/usr/bin/whonix-gateway-firewall.nftables
+++ b/usr/bin/whonix-gateway-firewall.nftables
@@ -91,7 +91,8 @@ variables_defaults() {
   [ -n "$ALLOW_GATEWAY_USER_USER" ] || ALLOW_GATEWAY_USER_USER=0
   [ -n "$GATEWAY_ALLOW_INCOMING_SSH" ] || GATEWAY_ALLOW_INCOMING_SSH=0
   [ -n "$GATEWAY_ALLOW_INCOMING_ICMP" ] || GATEWAY_ALLOW_INCOMING_ICMP=0
-
+  [ -n "$GATEWAY_ALLOW_INCOMING_ICMP_FRAG_NEEDED" ] || GATEWAY_ALLOW_INCOMING_ICMP_FRAG_NEEDED=0
+  
   ## Get Tor username, distro specific!
   [ -n "$TOR_USER" ] || TOR_USER="$(id -u debian-tor)"
 
@@ -437,6 +438,14 @@ nft_input_rules() {
   else
     #$iptables_cmd -A INPUT -m state --state ESTABLISHED -j ACCEPT
     $nftables_cmd add rule ip filter INPUT ct state established counter accept
+  fi
+
+  ## Allow fragmentation-needed ICMP packets to avoid MTU problems
+  ## when Whonix Gateway is connected to a link that has smaller
+  ## MTU than 1500 assumed by Whonix Gateway
+  if [ "$GATEWAY_ALLOW_INCOMING_ICMP_FRAG_NEEDED" = "1" ]; then
+    #$iptables_cmd -A INPUT -p icmp --icmp-type fragmentation-needed -m state --state RELATED -j ACCEPT
+    $nftables_cmd add rule filter INPUT icmp type destination-unreachable icmp code frag-needed ct state related counter accept
   fi
 
   ## Drop all incoming ICMP traffic by default.

--- a/usr/bin/whonix-host-firewall
+++ b/usr/bin/whonix-host-firewall
@@ -147,6 +147,13 @@ iptables -A INPUT -i lo -j ACCEPT
 ## Established incoming connections are accepted.
 iptables -A INPUT -m state --state ESTABLISHED -j ACCEPT
 
+## Allow fragmentation-needed ICMP packets to avoid MTU problems
+## when Whonix Gateway is connected to a link that has smaller
+## MTU than 1500 assumed by Whonix Gateway
+if [ "$GATEWAY_ALLOW_INCOMING_ICMP_FRAG_NEEDED" = "1" ]; then
+  iptables -A INPUT -p icmp --icmp-type fragmentation-needed -m state --state RELATED -j ACCEPT
+fi
+
 ## Drop all incoming ICMP traffic by default.
 ## All incoming connections are dropped by default anyway, but should a user
 ## allow incoming ports (such as for incoming SSH or FlashProxy), ICMP should


### PR DESCRIPTION
Add `GATEWAY_ALLOW_INCOMING_ICMP_FRAG_NEEDED` option to allow RELATED fragmentation-needed ICMP.
This fixes the problem with unstable or broken network connection over the link that has less than 1500 MTU assumed by Whonix-Gateway. For example in case of ISP using PPTP or user using Whonix-Gateway over VPN.

More info:
https://serverfault.com/a/376757
https://github.com/Whonix/whonix-firewall/commit/f604259dd55e5dde4765ac7e2ad095d95258caa0
http://forums.dds6qkxpwdeubwucdiaord2xgbbeyds25rbsgr73tbfpqpt4a6vjwsyd.onion/t/have-firewall-accept-icmp-fragmentation-needed/10233
http://forums.dds6qkxpwdeubwucdiaord2xgbbeyds25rbsgr73tbfpqpt4a6vjwsyd.onion/t/tor-is-not-yet-fully-bootstrapped-30-done/8792