### PR TITLE
Allow input connections to HTTPTunnelPort 

### DIFF
--- a/usr/bin/whonix-gateway-firewall
+++ b/usr/bin/whonix-gateway-firewall
@@ -511,10 +511,10 @@ ipv4_input_rules() {
         $iptables_cmd -A INPUT -i "$int_tif_item" -p tcp --dport "$socks_port" -j ACCEPT
       done
 
-      ## Accept ports 9152-9189 prepared for user custom applications.
+      ## Accept ports 9152-9229 prepared for user custom applications.
       ## See /usr/share/tor/tor-service-defaults-torrc for more comments.
-      [ "${info_enabled}" = "1" ] && output_cmd "INFO: opening TCP port(s) 9152:9189 for user custom applications"
-      $iptables_cmd -A INPUT -i "$int_tif_item" -p tcp --match multiport --dports 9152:9189 -j ACCEPT
+      [ "${info_enabled}" = "1" ] && output_cmd "INFO: opening TCP port(s) 9152:9229 for user custom applications"
+      $iptables_cmd -A INPUT -i "$int_tif_item" -p tcp --match multiport --dports 9152:9229 -j ACCEPT
     fi
   done
 
@@ -531,8 +531,8 @@ ipv4_input_rules() {
         $iptables_cmd -t nat -A PREROUTING -i "$int_if_item" -d "$WORKSTATION_DEST_SOCKSIFIED" -p tcp --dport "$socks_port" -j REDIRECT --to-ports "$socks_port"
       done
 
-      ## Redirect ports 9152-9189 prepared for user custom applications.
-      $iptables_cmd -t nat -A PREROUTING -i "$int_if_item" -d "$WORKSTATION_DEST_SOCKSIFIED" -p tcp --dport 9152:9189 -j REDIRECT
+      ## Redirect ports 9152-9229 prepared for user custom applications.
+      $iptables_cmd -t nat -A PREROUTING -i "$int_if_item" -d "$WORKSTATION_DEST_SOCKSIFIED" -p tcp --dport 9152:9229 -j REDIRECT
     fi
 
     if [ "$WORKSTATION_TRANSPARENT_DNS" = "1" ]; then

--- a/usr/bin/whonix-gateway-firewall.nftables
+++ b/usr/bin/whonix-gateway-firewall.nftables
@@ -580,11 +580,11 @@ nft_input_rules() {
         $nftables_cmd add rule inet filter input iifname "$int_tif_item" tcp dport "$socks_port" counter accept
       done
 
-      ## Accept ports 9152-9189 prepared for user custom applications.
+      ## Accept ports 9152-9229 prepared for user custom applications.
       ## See /usr/share/tor/tor-service-defaults-torrc for more comments.
-      [ "${info_enabled}" = "1" ] && output_cmd "INFO: opening TCP port(s) 9152:9189 for user custom applications"
-      #$iptables_cmd -A input -i "$int_tif_item" -p tcp --match multiport --dports 9152:9189 -j ACCEPT
-      $nftables_cmd add rule inet filter input iifname "$int_tif_item" tcp dport 9152-9189 counter accept
+      [ "${info_enabled}" = "1" ] && output_cmd "INFO: opening TCP port(s) 9152:9229 for user custom applications"
+      #$iptables_cmd -A input -i "$int_tif_item" -p tcp --match multiport --dports 9152:9229 -j ACCEPT
+      $nftables_cmd add rule inet filter input iifname "$int_tif_item" tcp dport 9152-9229 counter accept
     fi
   done
 
@@ -609,11 +609,11 @@ nft_input_rules() {
         done
       done
 
-      ## Redirect ports 9152-9189 prepared for user custom applications.
+      ## Redirect ports 9152-9229 prepared for user custom applications.
       local non_tor_gateway_item
       for workstation_dest_socksified_item in $WORKSTATION_DEST_SOCKSIFIED; do
-        #$iptables_cmd -t nat -A prerouting -i "$int_if_item" -d "$workstation_dest_socksified_item" -p tcp --dport 9152:9189 -j REDIRECT
-        $nftables_cmd add rule inet nat prerouting iifname "$int_if_item" ip daddr "$workstation_dest_socksified_item" tcp dport 9152-9189 counter redirect
+        #$iptables_cmd -t nat -A prerouting -i "$int_if_item" -d "$workstation_dest_socksified_item" -p tcp --dport 9152:9229 -j REDIRECT
+        $nftables_cmd add rule inet nat prerouting iifname "$int_if_item" ip daddr "$workstation_dest_socksified_item" tcp dport 9152-9229 counter redirect
       done
     fi
 


### PR DESCRIPTION
Allow input connections to HTTPTunnelPort.
HTTPTunnelPort support was added with this commit but the changes weren't made for firewall:
https://github.com/Whonix/anon-gw-anonymizer-config/commit/68daef8443eb4845ba07dc33b983df3592d5bccd