### PR TITLE
Fix nftables firewall version for Qubes

### DIFF
--- a/usr/bin/whonix-gateway-firewall.nftables
+++ b/usr/bin/whonix-gateway-firewall.nftables
@@ -318,11 +318,12 @@ nft_defaults() {
   #$iptables_cmd -t nat -X
   #$iptables_cmd -t mangle -F
   #$iptables_cmd -t mangle -X
-  $nftables_cmd flush ruleset
 
   $nftables_cmd add table inet nat
+  $nftables_cmd add table inet filter
 
-  $nftables_cmd create table inet filter
+  $nftables_cmd flush table inet nat
+  $nftables_cmd flush table inet filter
 
   ## Set secure defaults.
   #$iptables_cmd -P input DROP

--- a/usr/bin/whonix-workstation-firewall.nftables
+++ b/usr/bin/whonix-workstation-firewall.nftables
@@ -207,10 +207,12 @@ nft_defaults() {
   #$iptables_cmd -t nat -X
   #$iptables_cmd -t mangle -F
   #$iptables_cmd -t mangle -X
-  $nftables_cmd flush ruleset
 
   $nftables_cmd add table inet filter
   $nftables_cmd add table inet nat
+
+  $nftables_cmd flush table inet filter
+  $nftables_cmd flush table inet nat
 
   $nftables_cmd add chain inet nat output
   $nftables_cmd add chain inet nat prerouting

--- a/usr/libexec/whonix-firewall/enable-firewall.nftables
+++ b/usr/libexec/whonix-firewall/enable-firewall.nftables
@@ -1,0 +1,71 @@
+#!/bin/bash -e
+# vim: set ts=4 sw=4 sts=4 et :
+#
+# enable-firewall - Called by systemd to setup a proper firewall for
+#                   Whonix-Gateway or Whonix-Workstation.
+#
+# This file is part of Qubes+Whonix.
+# Copyright (C) 2014 - 2015 Jason Mehring <nrgaway@gmail.com>
+# Copyright (C) 2014 - 2023 ENCRYPTED SUPPORT LP <adrelanos@whonix.org>
+# License: GPL-2+
+# Authors: Jason Mehring
+# Authors: Patrick Schleizer
+#
+#   This program is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License
+#   as published by the Free Software Foundation; either version 2
+#   of the License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+#### meta start
+#### project Whonix
+#### category networking and firewall
+#### description
+## Wrapper to start firewall and create failure status files on failure.
+#### meta end
+
+[ -n "$nftables_cmd" ] || nftables_cmd="nft"
+
+failed_status_file_create() {
+  mkdir -p /run/anon-firewall || true
+  touch /run/anon-firewall/failed.status || true
+
+  ## Legacy.
+  ## mkdir should not be required for Qubes-Whonix, just as a defensive action.
+  ## mkdir is required for simpler Non-Qubes-Whonix code.
+  mkdir -p /run/qubes-service || true
+  touch /run/qubes-service/whonix-firewall-failed || true
+}
+
+firewall_lockdown() {
+  $nftables_cmd add table inet nat
+  $nftables_cmd add table inet filter
+
+  ## Flush old rules.
+  $nftables_cmd flush table inet nat
+  $nftables_cmd flush table inet filter
+
+  ## Set secure defaults.
+  $nftables_cmd "add chain inet filter input { type filter hook input priority 0; policy drop; }"
+  $nftables_cmd "add chain inet filter forward { type filter hook forward priority 0; policy drop; }"
+  $nftables_cmd "add chain inet filter output { type filter hook output priority 0; policy drop; }"
+}
+
+on_failure() {
+  failed_status_file_create
+  firewall_lockdown || true
+  exit 1
+}
+
+if [ -e /usr/share/anon-gw-base-files/gateway ] || [ -e /usr/share/anon-ws-base-files/workstation ]; then
+  /usr/bin/whonix_firewall || on_failure
+else
+  on_failure
+fi


### PR DESCRIPTION
## Changes

This pull request changes the nftables firewall version to flush only rules of tables it creates, without flushing other tables, such as the ones created by qubes. Additionally if fixes a "tables already exists" error in the gateway firewall, when executed a second time.

## Mandatory Checklist

- [X] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.whonix.org/wiki/Terms_of_Service), [Privacy Policy](https://www.whonix.org/wiki/Privacy_Policy), [Cookie Policy](https://www.whonix.org/wiki/Cookie_Policy), [E-Sign Consent](https://www.whonix.org/wiki/E-Sign_Consent), [DMCA](https://www.whonix.org/wiki/DMCA), [Imprint](https://www.whonix.org/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [X] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

