### PR TITLE
Add clarifying comments to firewall restart logic

### DIFF
--- a/usr/libexec/whonix-firewall/firewall-restarter
+++ b/usr/libexec/whonix-firewall/firewall-restarter
@@ -37,6 +37,8 @@ mkfifo "$inotifywait_subshell_fifo"
 inotifywait_subshell_pid="$!"
 
 if [ -f "/run/sdwdate/first_success" ] || [ -f "/run/updatesproxycheck/whonix-secure-proxy" ]; then
+  ## Intentionally only restart if whonix-firewall is currently active.
+  ## If the firewall is in a failed or inactive state, do not restart it here.
   if systemctl --no-pager --no-block status whonix-firewall; then
     systemctl --no-pager --no-block restart whonix-firewall || true
   fi
@@ -44,6 +46,8 @@ fi
 
 while read -r file_name; do
   if [ "$file_name" = "/run/sdwdate/first_success" ] || [ "$file_name" = "/run/updatesproxycheck/whonix-secure-proxy" ]; then
+    ## Intentionally only restart if whonix-firewall is currently active.
+    ## If the firewall is in a failed or inactive state, do not restart it here.
     if systemctl --no-pager --no-block status whonix-firewall; then
       systemctl --no-pager --no-block restart whonix-firewall || true
     fi


### PR DESCRIPTION
## Summary
Added explanatory comments to the firewall restart logic in the firewall-restarter script to clarify the intentional behavior of only restarting the firewall when it is currently active.

## Key Changes
- Added comments before the initial firewall status check explaining that restarts only occur when whonix-firewall is actively running
- Added identical comments before the firewall status check in the file monitoring loop for consistency
- Comments clarify that if the firewall is in a failed or inactive state, it will not be restarted by this script

## Implementation Details
The comments document the existing conditional behavior where `systemctl status` is used as a guard to prevent restarting the firewall service if it's not currently active. This is an important safety mechanism to avoid interfering with intentional firewall shutdowns or failed states.

https://claude.ai/code/session_017by8Udk9uMM21QgxeibA5S